### PR TITLE
Upload bin directory only in Release

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -53,15 +53,15 @@ jobs:
       run: dotnet test -c $env:Configuration
       env:
         Configuration: ${{ matrix.configuration }}
-      
+
     # Upload bin directory
     - name: Upload bin directory
       uses: actions/upload-artifact@main
-      if: ${{ success() }}
+      if: ${{ success() && matrix.configuration == 'Release' }}
       with:
         name: ToastFish_Build
         path: ./bin/Release/
-    
+
     # Delete workflow runs
     - name: Delete workflow runs
       uses: GitRML/delete-workflow-runs@main


### PR DESCRIPTION

仅当 Release 模式下才上传构建文件夹，使工作流不出现 `No files were found with the provided path: ./bin/Release/. No artifacts will be uploaded.` 警告。