### PR TITLE
修复：日语单词点记住时闪退

### DIFF
--- a/Model/SqliteControl/Select.cs
+++ b/Model/SqliteControl/Select.cs
@@ -94,7 +94,7 @@ namespace ToastFish.Model.SqliteControl
         public void UpdateCount()
         {
             BookCount Temp = new BookCount();
-            CountList = DataBase.Query<BookCount>($"select * from Count where bookName = {TABLE_NAME}", Temp);
+            CountList = DataBase.Query<BookCount>($"select * from Count where bookName = '{TABLE_NAME}'", Temp);
             var CountArray = CountList.ToArray();
             foreach (var OneCount in CountArray)
             {


### PR DESCRIPTION
UpdateCount 方法，SQL里 bookName 条件里等号右侧没有用引号括起来导致查询 SQL 异常