### PR TITLE
修复因缺失Log文件夹导致随机测试闪退的问题。

### DIFF
--- a/Model/Mp3/PlayMp3.cs
+++ b/Model/Mp3/PlayMp3.cs
@@ -21,8 +21,8 @@ namespace ToastFish.Model.Mp3
         private string Name = "";
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
         private string durLength = "";
-        [MarshalAs(UnmanagedType.LPTStr, SizeConst = 128)]
-        private string TemStr = "";
+        //[MarshalAs(UnmanagedType.LPTStr, SizeConst = 128)]
+        //private string TemStr = "";
         int ilong;
         //定义播放状态枚举变量
         public enum State
@@ -54,7 +54,6 @@ namespace ToastFish.Model.Mp3
             {
                 try
                 {
-                    TemStr = new String('\0', 127);
                     Name = Name.PadLeft(260, ' ');
                     mc.iName = value;
                     ilong = APIClass.GetShortPathName(mc.iName, Name, Name.Length);
@@ -73,9 +72,9 @@ namespace ToastFish.Model.Mp3
                     }
 
                     //Name = "open " + Convert.ToChar(34) + Name + Convert.ToChar(34) + " alias media";
-                    ilong = APIClass.mciSendString("close all", TemStr, TemStr.Length, 0);
-                    ilong = APIClass.mciSendString(Name, TemStr, TemStr.Length, 0);
-                    ilong = APIClass.mciSendString("set media time format milliseconds", TemStr, TemStr.Length, 0);
+                    ilong = APIClass.mciSendString("close all", IntPtr.Zero, 0, 0);
+                    ilong = APIClass.mciSendString(Name, IntPtr.Zero, 0, 0);
+                    ilong = APIClass.mciSendString("set media time format milliseconds", IntPtr.Zero, 0, 0);
                     mc.state = State.mStop;
                 }
                 catch
@@ -86,23 +85,21 @@ namespace ToastFish.Model.Mp3
         //播放
         public void play()
         {
-            TemStr = new String('\0', 127);
-            APIClass.mciSendString("play media", TemStr, TemStr.Length, 0);
-            //APIClass.mciSendString("play media", null, 0, 0);
+            //TemStr = new String('\0', 128);
+			//APIClass.mciSendString("play media", TemStr, TemStr.Length, 0);
+			APIClass.mciSendString("play media", IntPtr.Zero, 0, 0);
             mc.state = State.mPlaying;
         }
         //停止
         public void StopT()
         {
-            TemStr = new String('\0', 128);
-            ilong = APIClass.mciSendString("close media", TemStr, 128, 0);
-            ilong = APIClass.mciSendString("close all", TemStr, 128, 0);
+            ilong = APIClass.mciSendString("close media", IntPtr.Zero, 0, 0);
+            ilong = APIClass.mciSendString("close all", IntPtr.Zero, 0, 0);
             mc.state = State.mStop;
         }
         public void Puase()
         {
-            TemStr = new String('\0', 128);
-            ilong = APIClass.mciSendString("pause media", TemStr, TemStr.Length, 0);
+            ilong = APIClass.mciSendString("pause media", IntPtr.Zero, 0, 0);
             mc.state = State.mPuase;
         }
         private string GetCurrPath(string name)
@@ -178,16 +175,23 @@ namespace ToastFish.Model.Mp3
     {
         [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
         public static extern int GetShortPathName(
-         string lpszLongPath,
-         string shortFile,
-         int cchBuffer
-      );
+            string lpszLongPath,
+            string shortFile,
+            int cchBuffer
+        );
         [DllImport("winmm.dll", EntryPoint = "mciSendString", CharSet = CharSet.Auto)]
         public static extern int mciSendString(
-           string lpstrCommand,
-           string lpstrReturnString,
-           int uReturnLength,
-           int hwndCallback
-          );
+            string lpstrCommand,
+            string lpstrReturnString,
+            int uReturnLength,
+            int hwndCallback
+        );
+        [DllImport("winmm.dll", EntryPoint = "mciSendString", CharSet = CharSet.Auto)]
+        public static extern int mciSendString(
+            string lpstrCommand,
+            IntPtr lpstrReturnString,
+            int uReturnLength,
+            int hwndCallback
+        );
     }
 }

--- a/Model/Mp3/PlayMp3.cs
+++ b/Model/Mp3/PlayMp3.cs
@@ -54,9 +54,8 @@ namespace ToastFish.Model.Mp3
             {
                 try
                 {
-                    TemStr = "";
-                    TemStr = TemStr.PadLeft(127, Convert.ToChar(" "));
-                    Name = Name.PadLeft(260, Convert.ToChar(" "));
+                    TemStr = new String('\0', 127);
+                    Name = Name.PadLeft(260, ' ');
                     mc.iName = value;
                     ilong = APIClass.GetShortPathName(mc.iName, Name, Name.Length);
                     Name = GetCurrPath(Name);
@@ -87,8 +86,7 @@ namespace ToastFish.Model.Mp3
         //播放
         public void play()
         {
-            TemStr = "";
-            TemStr = TemStr.PadLeft(127, Convert.ToChar(" "));
+            TemStr = new String('\0', 127);
             APIClass.mciSendString("play media", TemStr, TemStr.Length, 0);
             //APIClass.mciSendString("play media", null, 0, 0);
             mc.state = State.mPlaying;
@@ -96,16 +94,14 @@ namespace ToastFish.Model.Mp3
         //停止
         public void StopT()
         {
-            TemStr = "";
-            TemStr = TemStr.PadLeft(128, Convert.ToChar(" "));
+            TemStr = new String('\0', 128);
             ilong = APIClass.mciSendString("close media", TemStr, 128, 0);
             ilong = APIClass.mciSendString("close all", TemStr, 128, 0);
             mc.state = State.mStop;
         }
         public void Puase()
         {
-            TemStr = "";
-            TemStr = TemStr.PadLeft(128, Convert.ToChar(" "));
+            TemStr = new String('\0', 128);
             ilong = APIClass.mciSendString("pause media", TemStr, TemStr.Length, 0);
             mc.state = State.mPuase;
         }
@@ -121,8 +117,7 @@ namespace ToastFish.Model.Mp3
         {
             get
             {
-                durLength = "";
-                durLength = durLength.PadLeft(128, Convert.ToChar(" "));
+                durLength = new String('\0', 128);
                 APIClass.mciSendString("status media length", durLength, durLength.Length, 0);
                 durLength = durLength.Trim();
                 if (durLength == "") return 0;
@@ -134,8 +129,7 @@ namespace ToastFish.Model.Mp3
         {
             get
             {
-                durLength = "";
-                durLength = durLength.PadLeft(128, Convert.ToChar(" "));
+                durLength = new String('\0', 128);
                 APIClass.mciSendString("status media position", durLength, durLength.Length, 0);
                 mc.iPos = (int)(Convert.ToDouble(durLength) / 1000f);
                 return mc.iPos;

--- a/Model/Mp3/PlayMp3.cs
+++ b/Model/Mp3/PlayMp3.cs
@@ -86,8 +86,8 @@ namespace ToastFish.Model.Mp3
         public void play()
         {
             //TemStr = new String('\0', 128);
-			//APIClass.mciSendString("play media", TemStr, TemStr.Length, 0);
-			APIClass.mciSendString("play media", IntPtr.Zero, 0, 0);
+            //APIClass.mciSendString("play media", TemStr, TemStr.Length, 0);
+            APIClass.mciSendString("play media", IntPtr.Zero, 0, 0);
             mc.state = State.mPlaying;
         }
         //停止

--- a/View/ToastFish.xaml.cs
+++ b/View/ToastFish.xaml.cs
@@ -344,11 +344,6 @@ namespace ToastFish
 
         private void Begin_Click(object sender, EventArgs e)
         {
-            if (!System.IO.Directory.Exists("Log"))  {
-                System.IO.Directory.CreateDirectory("Log");
-            }
-           // System.IO.Directory.CreateDirectory("Log");
-
             var state = thread.ThreadState;
 
             WordType Words = new WordType();
@@ -446,11 +441,6 @@ namespace ToastFish
                 System.Windows.Forms.MessageBox.Show("导入文件出错！");
                 return;
             }
-            
-            if (!Directory.Exists("Log")){
-                System.IO.Directory.CreateDirectory("Log");
-            }
-            
 
             var state = thread.ThreadState;
 

--- a/View/ToastFish.xaml.cs
+++ b/View/ToastFish.xaml.cs
@@ -41,6 +41,11 @@ namespace ToastFish
        //HotKey _hotKey0, _hotKey1, _hotKey2, _hotKey3, _hotKey4;
         public MainWindow()
         {
+            if (!Directory.Exists("Log"))
+            {
+                System.IO.Directory.CreateDirectory("Log");
+            }
+
             Form_Load();
             InitializeComponent();
             DataContext = Vm;

--- a/ViewModel/ViewModelLocator.cs
+++ b/ViewModel/ViewModelLocator.cs
@@ -14,7 +14,6 @@
 
 using CommonServiceLocator;
 using GalaSoft.MvvmLight.Ioc;
-using System.IO;
 
 namespace ToastFish.ViewModel
 {
@@ -29,11 +28,6 @@ namespace ToastFish.ViewModel
         /// </summary>
         public ViewModelLocator()
         {
-            if (!Directory.Exists("Log"))
-            {
-                System.IO.Directory.CreateDirectory("Log");
-            }
-
             ServiceLocator.SetLocatorProvider(() => SimpleIoc.Default);
             SimpleIoc.Default.Register<ToastFishModel>();
         }

--- a/ViewModel/ViewModelLocator.cs
+++ b/ViewModel/ViewModelLocator.cs
@@ -14,6 +14,7 @@
 
 using CommonServiceLocator;
 using GalaSoft.MvvmLight.Ioc;
+using System.IO;
 
 namespace ToastFish.ViewModel
 {
@@ -28,6 +29,11 @@ namespace ToastFish.ViewModel
         /// </summary>
         public ViewModelLocator()
         {
+            if (!Directory.Exists("Log"))
+            {
+                System.IO.Directory.CreateDirectory("Log");
+            }
+
             ServiceLocator.SetLocatorProvider(() => SimpleIoc.Default);
             SimpleIoc.Default.Register<ToastFishModel>();
         }


### PR DESCRIPTION
* 刚安装软件，啥也没干先试了试随机测试，结果抑制闪退。发现是没有log目录。为了避免之后出现相似的问题，直接将Log文件夹的创建放在程序启动。
* 浏览代码时看到一些（MUSIC类里的）蜜汁操作，改了一下。如果是有意而为之，请见谅。